### PR TITLE
Server Launch Fixes, Config CLI, and Better Setup UX

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,103 @@
+import { Command } from 'commander';
+import { loadConfig, saveConfig } from '../utils/config.js';
+import { success, error, info } from '../utils/ui.js';
+import { ConfigError } from '../utils/errors.js';
+
+export function configCommand(): Command {
+  const cmd = new Command('config')
+    .description('Manage HYT configuration');
+
+  cmd
+    .command('get')
+    .description('Display current configuration')
+    .option('--json', 'Output as JSON')
+    .addHelpText('after', `
+Examples:
+  $ hyt config get
+  $ hyt config get --json`)
+    .action(async (options: any) => {
+      try {
+        const config = await loadConfig();
+        if (!config) {
+          error('No configuration found. Run "hyt setup" first.');
+          process.exit(1);
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(config, null, 2));
+        } else {
+          console.log('\n📋 Current HYT Configuration:\n');
+          console.log(`Java Path:         ${config.javaPath}`);
+          console.log(`Hytale Install:    ${config.hytaleInstallPath}`);
+          if (config.jvmArgs && config.jvmArgs.length > 0) {
+            console.log(`JVM Arguments:     ${config.jvmArgs.join(' ')}`);
+          } else {
+            console.log(`JVM Arguments:     (using defaults: -Xmx2G -Xms1G)`);
+          }
+          console.log('');
+        }
+      } catch (err) {
+        error(`Failed to read configuration: ${(err as Error).message}`);
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command('set-jvm-args')
+    .description('Set JVM arguments for the Hytale server (heap size, GC tuning, etc.)')
+    .argument('[args...]', 'JVM arguments (e.g., -Xmx4G -Xms2G)')
+    .option('--reset', 'Reset to default JVM arguments (-Xmx2G -Xms1G)')
+    .addHelpText('after', `
+Examples:
+  $ hyt config set-jvm-args -Xmx4G -Xms2G
+    Increase max heap to 4GB, initial to 2GB
+  $ hyt config set-jvm-args -Xmx8G -Xms4G -XX:+UseG1GC
+    Use 8GB max with G1 garbage collector
+  $ hyt config set-jvm-args --reset
+    Reset to default arguments`)
+    .action(async (args: string[], options: any) => {
+      try {
+        const config = await loadConfig();
+        if (!config) {
+          error('No configuration found. Run "hyt setup" first.');
+          process.exit(1);
+        }
+
+        if (options.reset) {
+          delete config.jvmArgs;
+          await saveConfig(config);
+          success('✔ JVM arguments reset to defaults (-Xmx2G -Xms1G)');
+        } else if (args.length === 0) {
+          error('Please provide JVM arguments or use --reset to restore defaults.');
+          console.log('\nExamples:');
+          console.log('  hyt config set-jvm-args -Xmx4G -Xms2G');
+          console.log('  hyt config set-jvm-args -Xmx8G -Xms4G -XX:+UseG1GC');
+          console.log('  hyt config set-jvm-args --reset');
+          process.exit(1);
+        } else {
+          // Validate args start with - or --
+          const invalidArgs = args.filter(arg => !arg.startsWith('-'));
+          if (invalidArgs.length > 0) {
+            error(`Invalid JVM arguments: ${invalidArgs.join(', ')}`);
+            console.log('JVM arguments should start with - or --');
+            process.exit(1);
+          }
+
+          config.jvmArgs = args;
+          await saveConfig(config);
+          success(`✔ JVM arguments updated: ${args.join(' ')}`);
+        }
+
+        console.log('');
+      } catch (err) {
+        if (err instanceof ConfigError) {
+          error(err.message);
+        } else {
+          error(`Failed to update configuration: ${(err as Error).message}`);
+        }
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -80,11 +80,14 @@ export function devCommand(): Command {
 
         // Start Hytale server
         info('Starting Hytale server...\n');
+        // Use JVM args from config, or fall back to defaults
+        const defaultJvmArgs = ['-Xmx2G', '-Xms1G'];
         const serverOptions = {
           javaPath: config.javaPath,
           serverJarPath,
           assetsPath,
           workingDir: projectDir,
+          jvmArgs: config.jvmArgs || defaultJvmArgs,
         };
 
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { initCommand } from './commands/init.js';
 import { buildCommand } from './commands/build.js';
 import { devCommand } from './commands/dev.js';
 import { referencesCommand } from './commands/references.js';
+import { configCommand } from './commands/config.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -19,6 +20,7 @@ program
   .version(version);
 
 program.addCommand(setupCommand());
+program.addCommand(configCommand());
 program.addCommand(initCommand());
 program.addCommand(buildCommand());
 program.addCommand(devCommand());

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ import { getConfigDir, getConfigPath } from './paths.js';
 export interface ConfigSchema {
   javaPath: string;
   hytaleInstallPath: string;
+  jvmArgs?: string[]; // JVM arguments like ['-Xmx2G', '-Xms1G']
 }
 
 /** Load configuration from ~/.hyt/config.json */
@@ -44,5 +45,6 @@ export function validateConfig(config: Partial<ConfigSchema>): config is ConfigS
     config.javaPath.length > 0 &&
     typeof config.hytaleInstallPath === 'string' &&
     config.hytaleInstallPath.length > 0
+    // jvmArgs is optional, no validation needed
   );
 }

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -10,11 +10,12 @@ export interface ServerOptions {
   serverJarPath: string;
   assetsPath?: string;
   workingDir: string;
+  jvmArgs?: string[]; // e.g., ['-Xmx2G', '-Xms1G']
 }
 
 /** Launch the Hytale server */
 export function launchHytaleServer(options: ServerOptions): void {
-  const { javaPath, serverJarPath, assetsPath, workingDir } = options;
+  const { javaPath, serverJarPath, assetsPath, workingDir, jvmArgs = [] } = options;
 
   try {
     // Stop existing server if running
@@ -22,8 +23,8 @@ export function launchHytaleServer(options: ServerOptions): void {
       stopHytaleServer();
     }
 
-    // Build command args - only include --assets if provided
-    const args = ['-jar', serverJarPath];
+    // Build command args - JVM args first, then -jar, then server args
+    const args = [...jvmArgs, '-jar', serverJarPath];
     if (assetsPath) {
       args.push('--assets', assetsPath);
     }


### PR DESCRIPTION
## Fixes & Features

This PR addresses [Issue #2](https://github.com/LunnosMp4/hyt/issues/2) and introduces several improvements for usability and configuration.

### Bug Fixes
- Prevents CLI crash when the Hytale server exits with code 7 (or other non-zero codes).
- Improves error handling and reporting for server startup failures.

### Features
- **JVM Arguments Configurable:** Users can now set JVM arguments (e.g., memory limits) via `~/.hyt/config.json` or the CLI.
- **New CLI Command:** Added `hyt config set-jvm-args` to update JVM arguments without manually editing the config file.
- **Better Help & Examples:** All relevant commands now display clear usage examples in their help output.
- **Improved Setup Error Messages:** When specifying a Hytale path, the setup command now explains which folders are checked and clarifies that you can provide either the base Hytale folder or the full path to `Assets.zip`.

### Usage Examples

**Set JVM arguments:**
```sh
hyt config set-jvm-args -Xmx4G -Xms2G
hyt config set-jvm-args --reset
```
